### PR TITLE
Use SRI when fetching Bootstrap CSS

### DIFF
--- a/404.php
+++ b/404.php
@@ -34,7 +34,7 @@ echo <<<EOF
 			<link rel="icon" type="image/x-icon" href="https://meta.miraheze.org/favicon.ico" />
 			<link rel="apple-touch-icon" href="https://meta.miraheze.org/apple-touch-icon.png" />
 			<!-- Bootstrap core CSS -->
-			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" />
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" />
 			<style>
 				/* Error Page Inline Styles */
 				body {

--- a/502.html
+++ b/502.html
@@ -8,7 +8,7 @@
 		<title>502 Bad Gateway</title>
 		<link rel="shortcut icon" href="/favicon.ico" />
 		<!-- Bootstrap core CSS -->
-		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" />
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" />
 		<style>
 			/* Error Page Inline Styles */
 			body {

--- a/504.php
+++ b/504.php
@@ -18,7 +18,7 @@ echo <<<EOF
 			<link rel="icon" type="image/x-icon" href="https://meta.miraheze.org/favicon.ico" />
 			<link rel="apple-touch-icon" href="https://meta.miraheze.org/apple-touch-icon.png" />
 			<!-- Bootstrap core CSS -->
-			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" />
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" />
 			<style>
 				/* Error Page Inline Styles */
 				body {

--- a/MissingWiki.php
+++ b/MissingWiki.php
@@ -19,7 +19,7 @@ if ( !$wgCommandLineMode ) {
 				<link rel="icon" type="image/x-icon" href="https://meta.miraheze.org/favicon.ico" />
 				<link rel="apple-touch-icon" href="https://meta.miraheze.org/apple-touch-icon.png" />
 				<!-- Bootstrap core CSS -->
-				<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" />
+				<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" />
 				<style>
 					/* Error Page Inline Styles */
 					body {

--- a/databaseMaintenance.php
+++ b/databaseMaintenance.php
@@ -18,7 +18,7 @@ echo <<<EOF
 			<link rel="icon" type="image/x-icon" href="https://meta.miraheze.org/favicon.ico" />
 			<link rel="apple-touch-icon" href="https://meta.miraheze.org/apple-touch-icon.png" />
 			<!-- Bootstrap core CSS -->
-			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" />
+			<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" />
 			<style>
 				/* Error Page Inline Styles */
 				body {


### PR DESCRIPTION
This PR adds support for SRI when retrieving Bootstrap CSS. SubResource Integrity is a security measure to be used when retrieving content on CDNs to prevent a series of possible attacks. For an introduction on SRI, see https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity.

The hash is a SHA-384 hash created by me using OpenSSL 3.0.7. I generated it from both the Bootstrap GitHub 4.6.0 release (https://github.com/twbs/bootstrap/releases/tag/v4.6.0) and the file offered for download by jsdelivr, both returning the same hash.
