### PR TITLE
MissingWiki: wpSubdomain should not pass db name

### DIFF
--- a/MissingWiki.php
+++ b/MissingWiki.php
@@ -7,7 +7,7 @@ global $wgDBname;
 if ( MW_ENTRY_POINT !== 'cli' ) {
 	require_once __DIR__ . '/getTranslations.php';
 
-	$requestWikiUrl = 'https://meta.miraheze.org/wiki/Special:RequestWiki?wpsubdomain=' . $wgDBname;
+	$requestWikiUrl = 'https://meta.miraheze.org/wiki/Special:RequestWiki?wpsubdomain=' . substr($wgDBname, 0, -4);
 
 	$getLanguageCode = 'getLanguageCode';
 	$getTranslation = 'getTranslation';


### PR DESCRIPTION
Strip last 4 characters as suffix is always wiki to get the actual subdomain