### PR TITLE
Fix JSON error handling

### DIFF
--- a/getTranslations.php
+++ b/getTranslations.php
@@ -4,37 +4,6 @@ function getTranslation( $key ) {
 	if ( getLanguageCode() === 'qqx' ) {
 		return "({$key})";
 	}
-	
-	switch ( json_last_error() ) {
-		case JSON_ERROR_NONE:
-			$error = false;
-			break;
-		case JSON_ERROR_DEPTH:
-			$error = 'The maximum stack depth has been exceeded';
-			break;
-		case JSON_ERROR_STATE_MISMATCH:
-			$error = 'Invalid or malformed JSON';
-			break;
-		case JSON_ERROR_CTRL_CHAR:
-			$error = 'Control character error, possibly incorrectly encoded';
-			break;
-		case JSON_ERROR_SYNTAX:
-			$error = 'Syntax error';
-			break;
-		case JSON_ERROR_UTF8:
-			$error = 'Malformed UTF-8 characters, possibly incorrectly encoded';
-			break;
-		case JSON_ERROR_UTF16:
-			$error = 'Malformed UTF-16 characters, possibly incorrectly encoded';
-			break;
-		default:
-			$error = 'There was an unknown problem with the JSON';
-			break;
-	}
-
-	if ( $error ) {
-		throw new Exception( $error );
-	}
 
 	return preg_replace( '/\[(.*?)[\|| ](.*?)\]/', '<a href="$1">$2</a>',
 		nl2br( htmlspecialchars(
@@ -68,7 +37,7 @@ function getLanguageCode() {
 function getLocalisation() {
 	$lang = getLanguageCode();
 	if ( file_exists( __DIR__ . "/i18n/{$lang}.json" ) && $lang !== 'qqq' ) {
-		$translations = json_decode( file_get_contents( __DIR__ . "/i18n/{$lang}.json" ), true );
+		$translations = jsonDecodeOrThrow( file_get_contents( __DIR__ . "/i18n/{$lang}.json" ) );
 	} else {
 		$translations = getDefault();
 	}
@@ -82,14 +51,51 @@ function getFallback() {
 	$fallback = LOCALE_GET_PRIMARY_LANGUAGE( getLanguageCode() );
 
 	if ( file_exists( __DIR__ . "/i18n/{$fallback}.json" ) ) {
-		return json_decode( file_get_contents( __DIR__ . "/i18n/{$fallback}.json" ), true );
+		return jsonDecodeOrThrow( file_get_contents( __DIR__ . "/i18n/{$fallback}.json" ) );
 	}
 
 	return getDefault();
 }
 
 function getDefault() {
-	return json_decode( file_get_contents( __DIR__ . '/i18n/en.json' ), true );
+	return jsonDecodeOrThrow( file_get_contents( __DIR__ . '/i18n/en.json' ) );
+}
+
+function jsonDecodeOrThrow( string $input ) {
+	$decoded = json_decode( $input, true );
+
+	switch ( json_last_error() ) {
+		case JSON_ERROR_NONE:
+			$error = false;
+			break;
+		case JSON_ERROR_DEPTH:
+			$error = 'The maximum stack depth has been exceeded';
+			break;
+		case JSON_ERROR_STATE_MISMATCH:
+			$error = 'Invalid or malformed JSON';
+			break;
+		case JSON_ERROR_CTRL_CHAR:
+			$error = 'Control character error, possibly incorrectly encoded';
+			break;
+		case JSON_ERROR_SYNTAX:
+			$error = 'Syntax error';
+			break;
+		case JSON_ERROR_UTF8:
+			$error = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+			break;
+		case JSON_ERROR_UTF16:
+			$error = 'Malformed UTF-16 characters, possibly incorrectly encoded';
+			break;
+		default:
+			$error = 'There was an unknown problem with the JSON';
+			break;
+	}
+
+	if ( $error ) {
+		throw new Exception( $error );
+	}
+
+	return $decoded;
 }
 
 ?>


### PR DESCRIPTION
Previously, json_last_error was referring to any JSON error happening before any code in getTranslations was even run. This caused exceptions to be thrown if there was a json error during MW's bootstrapping process. Instead, handle errors after decoding any JSON.

Task: T14554